### PR TITLE
Remove swagger_ui_formatter and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,10 @@ WORKDIR /var/www/portal
 RUN composer require drush/drush
 RUN yes | ./vendor/drush/drush/drush init
 
-# install dependencies
-RUN composer require drupal/swagger_ui_formatter
-
 # configure apache
 RUN sed -i 's/DocumentRoot .*/DocumentRoot \/var\/www\/portal\/web/' /etc/apache2/sites-available/000-default.conf
 RUN mkdir -p /var/www/portal/web/sites/default/files
-RUN cp /var/www/portal/web/sites/default/default.settings.php /var/www/portal/web/sites/default/settings.php 
-
-# get swagger ui dependency
-WORKDIR /var/www/portal/web
-RUN mkdir -p libraries && curl -sSL https://github.com/swagger-api/swagger-ui/archive/v3.19.4.tar.gz -o swagger.tar.gz && tar -xvzf swagger.tar.gz && rm swagger.tar.gz  && mv swagger-ui-3.19.4 libraries/swagger_ui
+RUN cp /var/www/portal/web/sites/default/default.settings.php /var/www/portal/web/sites/default/settings.php
 
 # adding monetization module
 WORKDIR /var/www/portal
@@ -43,6 +36,3 @@ WORKDIR /var/www/portal
 ADD ./set-permissions.sh ./set-permissions.sh
 RUN chmod +x ./set-permissions.sh && ./set-permissions.sh --drupal_path=$(pwd)/web --drupal_user=root --httpd_group=www-data
 RUN chmod 777 ./web/sites/default/settings.php 
-
-
-


### PR DESCRIPTION
Since we switched to apigee_api_catalog module instead of swagger_ui_formatter, we no longer need the module or the library swagger_ui.